### PR TITLE
Need to apply m_fps setting when it is non-zero

### DIFF
--- a/src/V4l2Device.cpp
+++ b/src/V4l2Device.cpp
@@ -204,7 +204,7 @@ int V4l2Device::configureFormat(int fd)
 // configure capture FPS 
 int V4l2Device::configureParam(int fd)
 {
-	if (m_params.m_fps==0) 
+	if (m_params.m_fps!=0)
 	{
 		struct v4l2_streamparm   param;			
 		memset(&(param), 0, sizeof(param));


### PR DESCRIPTION
I noticed that h264_v4l2_rtspserver was failing to set the fps setting, this seems the obvious fix.
