### PR TITLE
Allow overriding of CXXFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -W -Wall -pthread -g -pipe $(EXTRA_CXXFLAGS)
+CXXFLAGS ?= -W -Wall -pthread -g -pipe $(EXTRA_CXXFLAGS)
 CXXFLAGS += -I inc
 RM = rm -rf
 CXX ?= $(CROSS)g++


### PR DESCRIPTION
This allows the OpenWrt build system to override the default CXXFLAGS for a smaller size.