### PR TITLE
mmap device: support fragmented writes

### DIFF
--- a/inc/V4l2Device.h
+++ b/inc/V4l2Device.h
@@ -18,6 +18,8 @@
 #include <linux/videodev2.h>
 #include <fcntl.h>
 
+#define V4L2WRAPPER_SUPPORT_PARTIAL_WRITE   1
+
 #ifndef V4L2_PIX_FMT_VP8
 #define V4L2_PIX_FMT_VP8  v4l2_fourcc('V', 'P', '8', '0')
 #endif
@@ -71,6 +73,9 @@ class V4l2Device
 
 		virtual bool init(unsigned int mandatoryCapabilities);		
 		virtual size_t writeInternal(char*, size_t) { return -1; }
+		virtual bool startPartialWrite(void)        { return false; }
+		virtual size_t writePartialInternal(char*, size_t) { return -1; }
+		virtual bool endPartialWrite(void)          { return false; }
 		virtual size_t readInternal(char*, size_t)  { return -1; }
 	
 	public:
@@ -97,6 +102,9 @@ class V4l2Device
 		unsigned int m_format;
 		unsigned int m_width;
 		unsigned int m_height;	
+
+		struct v4l2_buffer m_partialWriteBuf;
+		bool m_partialWriteInProgress;
 };
 
 

--- a/inc/V4l2Device.h
+++ b/inc/V4l2Device.h
@@ -18,8 +18,6 @@
 #include <linux/videodev2.h>
 #include <fcntl.h>
 
-#define V4L2WRAPPER_SUPPORT_PARTIAL_WRITE   1
-
 #ifndef V4L2_PIX_FMT_VP8
 #define V4L2_PIX_FMT_VP8  v4l2_fourcc('V', 'P', '8', '0')
 #endif

--- a/inc/V4l2MmapDevice.h
+++ b/inc/V4l2MmapDevice.h
@@ -21,6 +21,9 @@ class V4l2MmapDevice : public V4l2Device
 {	
 	protected:	
 		size_t writeInternal(char* buffer, size_t bufferSize);
+		bool startPartialWrite(void);
+		size_t writePartialInternal(char*, size_t);
+		bool endPartialWrite(void);
 		size_t readInternal(char* buffer, size_t bufferSize);
 			
 	public:

--- a/inc/V4l2Output.h
+++ b/inc/V4l2Output.h
@@ -29,6 +29,9 @@ class V4l2Output : public V4l2Access
 	
 		size_t write(char* buffer, size_t bufferSize);
 		int    isWritable(timeval* tv);
+		bool   startPartialWrite(void);
+		size_t writePartial(char* buffer, size_t bufferSize);
+		bool   endPartialWrite(void);
 };
 
 #endif

--- a/src/V4l2Output.cpp
+++ b/src/V4l2Output.cpp
@@ -87,3 +87,20 @@ size_t V4l2Output::write(char* buffer, size_t bufferSize)
 {
 	return m_device->writeInternal(buffer, bufferSize);
 }
+
+
+bool V4l2Output::startPartialWrite(void)
+{
+	return m_device->startPartialWrite();
+}
+
+size_t V4l2Output::writePartial(char* buffer, size_t bufferSize)
+{
+	return m_device->writePartialInternal(buffer, bufferSize);
+}
+
+bool V4l2Output::endPartialWrite(void)
+{
+	return m_device->endPartialWrite();
+}
+


### PR DESCRIPTION
When a video source produces fragmented video frames, it would be good if the fragments can be written straight into v4l2 buffer as we receive them and only queue the buffer when the frame is complete.

The typical way this would work is to dequeue a buffer on the reception of the first fragment of the video frame, then write the first fragment into the buffer. Keep appending subsequent fragments into the buffer.  When we have appended the last fragment into the buffer, we queue the buffer.